### PR TITLE
Create basic templates for Issues and Discussions

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/bug-reports.yml
+++ b/.github/DISCUSSION_TEMPLATE/bug-reports.yml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: JSharp Version
       description: Please enter the version of JSharp you are experiencing this issue on! If you built JSharp from source, provide the commit hash!
-      plaeholder: "0.2.4-beta.3"
+      placeholder: "0.2.4-beta.3"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,23 @@
+name: Bug Report
+description: Open a new bug report from a discussion
+body:
+  - type: input
+    attributes:
+      label: Related Discussion
+      description: What discussion is this issue derived from
+      placeholder: "Example: #6"
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Synopsis
+      description: Provide a synopsis of the issue
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Related Area
+      description: What area of JSharp is this issue related to?
+      placeholder: Example: CI/CD, Unit Tests, etc.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -4,14 +4,14 @@ body:
   - type: input
     attributes:
       label: Related Discussion
-      description: What discussion is this issue derived from
+      description: What discussion post is this issue related to?
       placeholder: "Example: #6"
     validations:
       required: true
   - type: textarea
     attributes:
       label: Synopsis
-      description: Provide a synopsis of the issue
+      description: Provide a brief summary of the issue
     validations:
       required: true
   - type: input
@@ -21,3 +21,8 @@ body:
       placeholder: "Example: CI/CD, Unit Tests, etc."
     validations:
       required: true
+  - type: checkboxes
+    attributes:
+      label: Meta Information
+      options:
+        - label: OP is willing to work on this feature

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -18,6 +18,6 @@ body:
     attributes:
       label: Related Area
       description: What area of JSharp is this issue related to?
-      placeholder: Example: CI/CD, Unit Tests, etc.
+      placeholder: "Example: CI/CD, Unit Tests, etc."
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug-reports.yml
+++ b/.github/ISSUE_TEMPLATE/bug-reports.yml
@@ -1,0 +1,57 @@
+title: "[BUG] "
+body:
+  - type: checkboxes
+    attributes:
+      label: Pre-Report Checklist
+      description: Please ensure that you have completed the following checklist **before** opening this bug report!
+      options:
+        - label: I have looked for a duplicate bug report
+          required: true
+        - label: I have not received an error code for my issue (please go to the support discussions for issues with an error code!)
+          required: true
+
+  - type: input
+    attributes:
+      label: JSharp Version
+      description: Please enter the version of JSharp you are experiencing this issue on! If you built JSharp from source, provide the commit hash!
+      plaeholder: "0.2.4-beta.3"
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: Please give a brief description of the problem.
+      placeholder: |
+        Example: The compiled .jar file is missing some of my C# classes
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Steps for Reproduction
+      description: |
+        Please provide a list of steps on how to reproduce the issue you're having
+        ##### Tip: Be as detailed as possible! This makes it easier for us to quickly identify the issue!
+      placeholder: |
+        1. Create a new project with JSharp
+        2. Make a new class "TestUIClass" in the folder "Tests/UI"
+        ...
+    validations:
+        required: true
+
+  - type: textarea
+    attributes:
+      label: Extra Info
+      description: |
+        Is there anything else you think we should know about your issue that wasn't covered above? Let us know here
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this bug report! We greatly appreciate it and will review this as soon as we can!
+        
+      
+        

--- a/.github/ISSUE_TEMPLATE/new-feature.yml
+++ b/.github/ISSUE_TEMPLATE/new-feature.yml
@@ -1,0 +1,26 @@
+name: New Feature
+description: Open an issue for a new feature discussed in a discussion post
+body:
+  - type: input
+    attributes:
+      label: Related Discussion
+      description: What discussion post is this feature related to?
+      placeholder: "Example: #87"
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Synopsis
+      description: Provide a brief summary of the new feature
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Related Area
+      description: What area of JSharp is this feature related to?
+      placeholder: "Example: Documentation, Unit Tests"
+  - type: checkboxes
+    attributes:
+      label: Meta Information
+      options:
+        - label: OP is willing to work on this feature

--- a/.github/ISSUE_TEMPLATE/new-feature.yml
+++ b/.github/ISSUE_TEMPLATE/new-feature.yml
@@ -19,6 +19,8 @@ body:
       label: Related Area
       description: What area of JSharp is this feature related to?
       placeholder: "Example: Documentation, Unit Tests"
+    validations:
+      required: true
   - type: checkboxes
     attributes:
       label: Meta Information


### PR DESCRIPTION
There is an explanation for the basic issue templates and a lack of info.

**The general flow of issues/feature requests from community members will go as follows:**
1. A discussion is opened
  - This allows for discussion about the issue/feature request before any official plans for implementing it are put into place.
  - The separation between Discussions and Issues allows for accurate tracking of currently planned work on JSharp, while still allowing community members to voice concerns and requests
  - *Discussions are one of the greatest things GitHub has added imo*
2. An issue is opened related to the issue/feature request
  - Once a discussion has reached a conclusion where the maintainers and/or community agree that the issue/feature request should be addressed, an official issue will be opened
  - This issue doesn't need much info and is mainly a visual tracker for the development progress on the related issue/feature request
3. A PR is opened containing the code related to the issue/feature request
  - Maintainers will eventually get around to working on the issue (depending on priority), so if you would like to see the issue resolved sooner, **try giving it a shot yourself**! All community members are encouraged to tackle open issues, whether you're a long-time GitHub user or it's your first-ever commit!
  - Code quality and unit testing will be reviewed by the code owner and another maintainer before merging. More details on this process can be found in the `CONTRIBUTING` file.
4. The issue is resolved, merged into `main`, and ready for the next release!

### This process will be detailed in the `CONTRIBUTING` file.